### PR TITLE
Fix remove redundancy

### DIFF
--- a/Module1/Task1.2P.cpp
+++ b/Module1/Task1.2P.cpp
@@ -14,9 +14,7 @@ void setup()
 }
 
 void loop()
-{
-  delay(500);
-}
+{}
 
 void handle()
 {

--- a/Module1/Task1.3C.cpp
+++ b/Module1/Task1.3C.cpp
@@ -30,9 +30,7 @@ void setup()
 }
 
 void loop()
-{
-  delay(500);
-}
+{}
 
 // motion sensor interrupt handler
 void handleMotionSensor()

--- a/Module1/Task1.4D.cpp
+++ b/Module1/Task1.4D.cpp
@@ -64,9 +64,7 @@ void setup()
 }
 
 void loop()
-{
-  delay(500);
-}
+{}
 
 // motion sensor interrupt handler
 void handleMotionSensor()


### PR DESCRIPTION
Removed the redundant use of delay() in the main loops of each file. Originally added to show that the main loop can do work and be interrupted from work by various types of interrupts.